### PR TITLE
Follow guidance to migrate from pyserial to serialx

### DIFF
--- a/tekmar_packetserv/CHANGELOG.md
+++ b/tekmar_packetserv/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.0
+- Migrate from pyserial to serialx
+
 ## 1.3.3
 - Update to base 3.23
 - Addons are now Apps

--- a/tekmar_packetserv/Dockerfile
+++ b/tekmar_packetserv/Dockerfile
@@ -5,7 +5,8 @@ FROM ${BUILD_FROM}
 ENV LANG=C.UTF-8
 
 # Install requirements for app
-RUN apk add --no-cache python3 py3-pip && pip3 install --no-cache-dir serialx
+RUN apk add --no-cache python3 py3-pip \
+    && pip3 install --no-cache-dir --break-system-packages serialx
 
 # Copy data
 COPY rootfs /

--- a/tekmar_packetserv/Dockerfile
+++ b/tekmar_packetserv/Dockerfile
@@ -5,7 +5,7 @@ FROM ${BUILD_FROM}
 ENV LANG=C.UTF-8
 
 # Install requirements for app
-RUN apk add --no-cache python3 py3-pyserial
+RUN apk add --no-cache python3 py3-pip && pip3 install --no-cache-dir serialx
 
 # Copy data
 COPY rootfs /

--- a/tekmar_packetserv/config.json
+++ b/tekmar_packetserv/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Tekmar Packet Server",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "url": "https://github.com/WillCodeForCats/tekmar-packetserv",
   "slug": "tekmar_packetserv",
   "description": "Connect with the Tekmar Gateway 482",

--- a/tekmar_packetserv/rootfs/usr/local/packetserv/packetserv.py
+++ b/tekmar_packetserv/rootfs/usr/local/packetserv/packetserv.py
@@ -10,7 +10,7 @@ import threading
 import traceback
 
 import packet
-import serial
+import serialx
 import tpck
 
 # ******************************************************************************
@@ -195,7 +195,7 @@ class RunSerial(threading.Thread):
                         self.connections.lst.remove(s)
                 self.connections.lock.release()
 
-        except serial.SerialException as err:
+        except (serialx.SerialException, OSError) as err:
             self.running = False
             message(err)
 
@@ -211,7 +211,7 @@ class RunSerial(threading.Thread):
         message("Serial port closing.")
         try:
             self.port.close()
-        except (select.error, serial.SerialException):
+        except (select.error, serialx.SerialException, OSError):
             pass
 
     # --------------------------------------------------------------------------
@@ -247,33 +247,33 @@ if __name__ == "__main__":
         try:
             if ser_mode == "device":
                 message(f"Opening serial port device: {ser_name}")
-                serial_port = serial.Serial(
+                serial_port = serialx.serial_for_url(
                     ser_name,
                     baudrate=9600,
-                    bytesize=serial.EIGHTBITS,
-                    parity=serial.PARITY_NONE,
-                    stopbits=serial.STOPBITS_ONE,
-                    timeout=TIMEOUT,
+                    byte_size=8,
+                    parity=serialx.Parity.NONE,
+                    stopbits=serialx.StopBits.ONE,
+                    read_timeout=TIMEOUT,
                 )
 
             if ser_mode == "rfc2217":
                 message(f"Opening RFC2217 connection to {ser_host} port {ser_port}")
-                serial_port = serial.serial_for_url(
+                serial_port = serialx.serial_for_url(
                     f"rfc2217://{ser_host}:{ser_port}",
                     baudrate=9600,
-                    bytesize=serial.EIGHTBITS,
-                    parity=serial.PARITY_NONE,
-                    stopbits=serial.STOPBITS_ONE,
-                    timeout=TIMEOUT,
+                    byte_size=8,
+                    parity=serialx.Parity.NONE,
+                    stopbits=serialx.StopBits.ONE,
+                    read_timeout=TIMEOUT,
                 )
 
             if ser_mode == "socket":
                 message(f"Opening socket connection to {ser_host} port {ser_port}")
-                serial_port = serial.serial_for_url(
-                    f"socket://{ser_host}:{ser_port}", timeout=TIMEOUT
+                serial_port = serialx.serial_for_url(
+                    f"socket://{ser_host}:{ser_port}", read_timeout=TIMEOUT
                 )
 
-        except serial.SerialException:
+        except (serialx.SerialException, OSError):
             message("Could not open serial port. Exiting.")
 
         else:


### PR DESCRIPTION
HA dev team recommends migrating from `pyserial` to `serialx`

https://developers.home-assistant.io/blog/2026/04/27/pyserial-to-serialx/